### PR TITLE
# add Sentry error tracking (logging integration)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -49,6 +49,11 @@ spec:
               value: "http://influxdb.apps.svc.cluster.local:8086"
             - name: JWKS_URI
               value: "http://auth-service.apps.svc.cluster.local:8080/auth/jwks"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: dsn
           livenessProbe:
             httpGet:
               path: /actuator/health

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,13 @@
 			<artifactId>awaitility</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Sentry error tracking -->
+		<dependency>
+			<groupId>io.sentry</groupId>
+			<artifactId>sentry-spring-boot-starter-jakarta</artifactId>
+			<version>8.34.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/ch/furchert/homelab/device/service/SchedulerService.java
+++ b/src/main/java/ch/furchert/homelab/device/service/SchedulerService.java
@@ -121,7 +121,7 @@ public class SchedulerService {
                 }
             } catch (IllegalArgumentException e) {
                 log.error("Invalid cron expression '{}' for schedule id={}: {}",
-                        schedule.getCronExpression(), schedule.getId(), e.getMessage());
+                        schedule.getCronExpression(), schedule.getId(), e.getMessage(), e);
             }
         }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,3 +59,15 @@ springdoc:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
+
+sentry:
+  dsn: ${SENTRY_DSN:}
+  environment: production
+  send-default-pii: false
+  traces-sample-rate: 0.0
+  logging:
+    enabled: true
+    minimum-event-level: ERROR
+    minimum-breadcrumb-level: WARN
+  tags:
+    service: device-service


### PR DESCRIPTION
  Adds sentry-spring-boot-starter-jakarta 8.34.1. All log.error() calls
  with a Throwable as the final argument are automatically captured as
  Sentry events. DSN is empty by default so tests are unaffected.
  SENTRY_DSN env var wired in k8s/deployment.yaml separately.

## attach exception to SchedulerService log.error for Sentry capture

  SLF4J only forwards the stack trace to appenders (and Sentry) when the
  final argument to log.error() is a Throwable. Was passing e.getMessage()
  (String), so the stack trace was missing from error tracking.

## add SENTRY_DSN env var to device-service K8s deployment

  References shared sentry-dsn K8s Secret provisioned by Ansible.
  Also renames deployment.yml → deployment.yaml for consistency.