### PR TITLE
# fix: replace sentry-spring-boot-starter-jakarta with sentry-spring-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,11 +177,11 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- Sentry error tracking -->
+		<!-- Sentry error tracking (Spring Boot 4 compatible artifact) -->
 		<dependency>
 			<groupId>io.sentry</groupId>
-			<artifactId>sentry-spring-boot-starter-jakarta</artifactId>
-			<version>8.34.1</version>
+			<artifactId>sentry-spring-boot-4</artifactId>
+			<version>8.38.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,6 +1,4 @@
 spring:
-  autoconfigure:
-    exclude: io.sentry.spring.boot.jakarta.SentryAutoConfiguration
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
…boot-4 for Spring Boot 4.0 compatibility

  sentry-spring-boot-starter-jakarta:8.34.1 targets Spring Boot 3 and references RestClientAutoConfiguration which was removed in Spring Boot 4.0's autoconfiguration restructuring. This caused a ClassNotFoundException
  at bean-name generation on startup, crash-looping the service.

  Replaced with io.sentry:sentry-spring-boot-4:8.38.0 (Sentry's official Spring Boot 4 artifact). Removed the now-stale spring.autoconfigure.exclude in test YAML — the class no longer exists on the classpath and Spring Boot
  would throw on an unknown exclusion. Tests use sentry.enabled: false instead.