### PR TITLE
# fix: skip build trigger on Flux image tag updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build and Push
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'k8s/**'
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
  Add paths-ignore: k8s/** to the push trigger in build.yml for both auth-service and device-service. Flux CD commits to k8s/deployment.yaml were re-triggering a full build+push on every image tag bump, creating a feedback loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to refine build trigger conditions, optimizing deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->