### PR TITLE
# test: expand coverage to 99 tests — service, handler, WebSocket, va…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '37 15 * * 6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -58,7 +62,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up JDK 25
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: '25'

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ replay_pid*
 # Test coverage
 coverage/
 .coverage
+/.opencode/opencode.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,12 @@ export DB_USERNAME=homelab
 export DB_PASSWORD=homelab
 export MQTT_PASSWORD=<mosquitto-backend-password>
 export INFLUX_TOKEN=<influxdb-admin-token>
+export DEVICE_SERVICE_CLIENT_SECRET=<oidc-client-secret>
 ./mvnw spring-boot:run
 ```
 
 The service connects to database `homelabdb` on `localhost:5432`, Mosquitto on `localhost:1883`, and InfluxDB on `localhost:8086` (defaults in `application.yaml`).
+Auth-service must be reachable for JWT JWKS validation (`http://localhost:8080/oauth2/jwks`) and for Swagger SSO login (`https://auth.furchert.ch`).
 
 ---
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -48,8 +48,11 @@ kubectl create secret generic device-service-secrets \
   --from-literal=db-username=<postgres-user> \
   --from-literal=db-password=<postgres-password> \
   --from-literal=mqtt-password=<mosquitto-backend-password> \
-  --from-literal=influx-token=<influxdb-admin-token>
+  --from-literal=influx-token=<influxdb-admin-token> \
+  --from-literal=device-service-client-secret=<oidc-client-secret>
 ```
+
+For auth-service client registration, store the same secret there with a Spring Security encoder prefix, e.g. `{noop}<oidc-client-secret>`.
 
 > In production, create this secret via the SOPS-backed Ansible playbook rather than `kubectl create` — see the cluster-level DEPLOYMENT.md for the secrets pattern.
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -116,7 +116,8 @@ All secrets are sourced from the `device-service-secrets` Kubernetes Secret (see
 | `INFLUX_URL` | Env / ConfigMap | InfluxDB HTTP endpoint (default: `http://influxdb.apps.svc.cluster.local:8086`) |
 | `INFLUX_ORG` | Env / ConfigMap | InfluxDB organisation (default: `homelab`) |
 | `INFLUX_BUCKET` | Env / ConfigMap | InfluxDB bucket for sensor data (default: `iot-bucket`) |
-| `JWKS_URI` | Env / ConfigMap | Auth-service JWKS endpoint (default: `http://auth-service.apps.svc.cluster.local:8080/auth/jwks`) |
+| `JWKS_URI` | Env / ConfigMap | Auth-service JWKS endpoint (default: `http://auth-service.apps.svc.cluster.local:8080/oauth2/jwks`) |
+| `DEVICE_SERVICE_CLIENT_SECRET` | Secret `device-service-secrets` / key `device-service-client-secret` | OIDC client secret for Swagger SSO login |
 
 ---
 
@@ -171,6 +172,15 @@ Common causes: database unreachable, migration checksum mismatch.
    ```bash
    kubectl describe deployment device-service -n apps | grep JWKS_URI
    ```
+
+### Swagger login redirect loop / OAuth2 login fails
+
+1. Confirm the client secret env var is present:
+   ```bash
+   kubectl describe deployment device-service -n apps | grep DEVICE_SERVICE_CLIENT_SECRET
+   ```
+2. Verify `device-service-secrets` contains key `device-service-client-secret`.
+3. Verify auth-service has a matching `device-service` OIDC client entry and the stored secret includes a Spring Security prefix (`{noop}` or `{bcrypt}`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Real-time IoT device management service for the doemefu homelab ecosystem -- MQT
 | POST | `/devices/{id}/control` | JWT | Send control command (publishes to MQTT) |
 | GET | `/actuator/health` | None | K8s liveness/readiness |
 | GET | `/actuator/info` | None | Service info |
-| GET | `/api-docs` | None | OpenAPI JSON spec |
-| GET | `/swagger-ui.html` | None | Swagger UI |
+| GET | `/api-docs` | OIDC login | OpenAPI JSON spec |
+| GET | `/swagger-ui.html` | OIDC login | Swagger UI |
+
+Unauthenticated browser requests to Swagger endpoints are automatically redirected to auth-service login and returned to Swagger after successful sign-in.
 
 ### WebSocket
 
@@ -92,6 +94,7 @@ export DB_USERNAME=homelab
 export DB_PASSWORD=homelab
 export MQTT_PASSWORD=<mqtt-password>
 export INFLUX_TOKEN=<influx-token>
+export DEVICE_SERVICE_CLIENT_SECRET=<oidc-client-secret>
 ```
 
 ### 3. Run
@@ -100,7 +103,7 @@ export INFLUX_TOKEN=<influx-token>
 ./mvnw spring-boot:run
 ```
 
-> The service connects to database `homelabdb` on `localhost:5432`, Mosquitto on `localhost:1883`, and InfluxDB on `localhost:8086` (defaults in `application.yaml`). Auth-service must be reachable at `localhost:8080` for JWKS validation.
+> The service connects to database `homelabdb` on `localhost:5432`, Mosquitto on `localhost:1883`, and InfluxDB on `localhost:8086` (defaults in `application.yaml`). Auth-service must be reachable at `localhost:8080` for JWKS validation and at `https://auth.furchert.ch` for Swagger SSO login.
 
 ---
 
@@ -120,7 +123,8 @@ export INFLUX_TOKEN=<influx-token>
 | `app.influxdb.token` | `INFLUX_TOKEN` | — (required) |
 | `app.influxdb.org` | — | `homelab` |
 | `app.influxdb.bucket` | — | `iot-bucket` |
-| `spring.security.oauth2.resourceserver.jwt.jwk-set-uri` | — | `http://localhost:8080/auth/jwks` |
+| `spring.security.oauth2.resourceserver.jwt.jwk-set-uri` | `JWKS_URI` | `http://localhost:8080/oauth2/jwks` |
+| `spring.security.oauth2.client.registration.device-service.client-secret` | `DEVICE_SERVICE_CLIENT_SECRET` | — (required for Swagger SSO) |
 | `app.scheduler.poll-interval` | — | `60000` ms (1 min) |
 | `spring.flyway.table` | — | `flyway_schema_history_device` |
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: device-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: device-service
           # Image tag is managed by Flux CD image automation.
@@ -49,7 +50,12 @@ spec:
             - name: INFLUX_URL
               value: "http://influxdb.apps.svc.cluster.local:8086"
             - name: JWKS_URI
-              value: "http://auth-service.apps.svc.cluster.local:8080/auth/jwks"
+              value: "http://auth-service.apps.svc.cluster.local:8080/oauth2/jwks"
+            - name: DEVICE_SERVICE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: device-service-secrets
+                  key: device-service-client-secret
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security-oauth2-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/ch/furchert/homelab/device/config/SecurityConfig.java
+++ b/src/main/java/ch/furchert/homelab/device/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
     @Order(2)
     public SecurityFilterChain apiSecurityFilterChain(HttpSecurity http) throws Exception {
         http
-            // Explicitly match everything NOT in Chain 1
+            // Catch-all matcher; acts as fallback because it has lower priority (@Order(2)) than Chain 1
             .securityMatcher("/**")
             // Allow WebSocket upgrade handshakes without CSRF token
             .csrf(csrf -> csrf

--- a/src/main/java/ch/furchert/homelab/device/config/SecurityConfig.java
+++ b/src/main/java/ch/furchert/homelab/device/config/SecurityConfig.java
@@ -2,18 +2,72 @@ package ch.furchert.homelab.device.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestCustomizers;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+    /**
+     * Chain 1 (order 1): session-based OAuth2 login for Swagger UI.
+     * Handles the OIDC Authorization Code flow with PKCE for browser access to documentation.
+     * Stores the authenticated principal in an HTTP session.
+     */
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    @Order(1)
+    public SecurityFilterChain swaggerSecurityFilterChain(
+            HttpSecurity http,
+            ClientRegistrationRepository clientRegistrationRepository) throws Exception {
+
+        DefaultOAuth2AuthorizationRequestResolver resolver =
+                new DefaultOAuth2AuthorizationRequestResolver(
+                        clientRegistrationRepository,
+                        "/oauth2/authorization");
+        resolver.setAuthorizationRequestCustomizer(
+                OAuth2AuthorizationRequestCustomizers.withPkce());
+
         http
+            .securityMatcher(
+                "/swagger-ui.html",
+                "/swagger-ui/**",
+                "/api-docs/**",
+                "/webjars/**",
+                "/login/oauth2/**",
+                "/oauth2/**"
+            )
+            .authorizeHttpRequests(auth -> auth
+                // Static assets for Swagger UI
+                .requestMatchers("/webjars/**").permitAll()
+                // Everything else in this chain requires authentication
+                .anyRequest().authenticated()
+            )
+            .oauth2Login(login -> login
+                .authorizationEndpoint(endpoint -> endpoint
+                    .authorizationRequestResolver(resolver)
+                )
+            );
+
+        return http.build();
+    }
+
+    /**
+     * Chain 2 (order 2): stateless resource server for REST API, WebSocket, actuator.
+     * Behaviour is identical to the previous single-chain configuration.
+     * This chain handles all requests NOT matched by Chain 1.
+     */
+    @Bean
+    @Order(2)
+    public SecurityFilterChain apiSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+            // Explicitly match everything NOT in Chain 1
+            .securityMatcher("/**")
             // Allow WebSocket upgrade handshakes without CSRF token
             .csrf(csrf -> csrf
                 .ignoringRequestMatchers("/ws/**")
@@ -27,8 +81,6 @@ public class SecurityConfig {
                 .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                 // WebSocket endpoint is read-only broadcast — no auth required
                 .requestMatchers("/ws/**").permitAll()
-                // OpenAPI / Swagger UI — documentation access without auth
-                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()
                 // Everything else requires a valid JWT
                 .anyRequest().authenticated()
             )

--- a/src/main/java/ch/furchert/homelab/device/config/SecurityConfig.java
+++ b/src/main/java/ch/furchert/homelab/device/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
             .securityMatcher(
                 "/swagger-ui.html",
                 "/swagger-ui/**",
+                "/api-docs",
                 "/api-docs/**",
                 "/webjars/**",
                 "/login/oauth2/**",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,7 +32,13 @@ spring:
             scope: openid,profile,email
         provider:
           auth-service:
-            issuer-uri: https://auth.furchert.ch
+            # Explicit endpoints avoid an OIDC discovery HTTP call at startup,
+            # so device-service can start independently of auth-service availability.
+            authorization-uri: https://auth.furchert.ch/oauth2/authorize
+            token-uri: https://auth.furchert.ch/oauth2/token
+            jwk-set-uri: https://auth.furchert.ch/oauth2/jwks
+            user-info-uri: https://auth.furchert.ch/userinfo
+            user-name-attribute: sub
 
 server:
   port: 8081

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,7 +20,19 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: ${JWKS_URI:http://localhost:8080/auth/jwks}
+          jwk-set-uri: ${JWKS_URI:http://localhost:8080/oauth2/jwks}
+      client:
+        registration:
+          device-service:
+            provider: auth-service
+            client-id: device-service
+            client-secret: ${DEVICE_SERVICE_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/device-service"
+            scope: openid,profile,email
+        provider:
+          auth-service:
+            issuer-uri: https://auth.furchert.ch
 
 server:
   port: 8081

--- a/src/test/java/ch/furchert/homelab/device/config/SecurityConfigTest.java
+++ b/src/test/java/ch/furchert/homelab/device/config/SecurityConfigTest.java
@@ -1,0 +1,112 @@
+package ch.furchert.homelab.device.config;
+
+import ch.furchert.homelab.device.controller.DeviceController;
+import ch.furchert.homelab.device.service.DeviceService;
+import ch.furchert.homelab.device.service.MqttClientService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DeviceController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = "DEVICE_SERVICE_CLIENT_SECRET=test")
+class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DeviceService deviceService;
+
+    @MockitoBean
+    private MqttClientService mqttClientService;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void swaggerUi_unauthenticated_redirectsToOAuth2Login() throws Exception {
+        mockMvc.perform(get("/swagger-ui/index.html"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/oauth2/authorization/device-service"));
+    }
+
+    @Test
+    void swaggerUi_authenticated_isNotRedirectedToLogin() throws Exception {
+        // Verify the security layer does NOT challenge an already-authenticated user.
+        // In @WebMvcTest, Springdoc may return 5xx because its resource handlers lack
+        // full context — that is an application error, not a security failure.
+        // The only security failures are: 401 (rejected) or 302 to the OAuth2 login URL.
+        var result = mockMvc.perform(get("/swagger-ui/index.html").with(oauth2Login())).andReturn();
+        int status = result.getResponse().getStatus();
+        String location = result.getResponse().getHeader("Location");
+        assertThat(status).isNotEqualTo(401);
+        assertThat(status == 302 && location != null && location.contains("oauth2/authorization"))
+                .as("authenticated user must not be redirected to OAuth2 login")
+                .isFalse();
+    }
+
+    @Test
+    void apiDevices_withoutJwt_returnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/devices"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void apiDevices_withJwt_isHandled() throws Exception {
+        when(deviceService.getAllDevices()).thenReturn(List.of());
+
+        mockMvc.perform(get("/devices").with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void actuatorHealth_isPublicOrMissingButNotAuthProtected() throws Exception {
+        int status = mockMvc.perform(get("/actuator/health")).andReturn().getResponse().getStatus();
+        assertThat(status).as("actuator/health must not require authentication").isNotIn(302, 401);
+    }
+
+    @Test
+    void actuatorInfo_isPublicOrMissingButNotAuthProtected() throws Exception {
+        int status = mockMvc.perform(get("/actuator/info")).andReturn().getResponse().getStatus();
+        assertThat(status).as("actuator/info must not require authentication").isNotIn(302, 401);
+    }
+
+    @Test
+    void webjars_unauthenticated_isPermitAll() throws Exception {
+        // /webjars/** is permitAll() in Chain 1 — Swagger UI static assets must load
+        // without triggering an OAuth2 redirect (the page would otherwise break).
+        var result = mockMvc.perform(get("/webjars/swagger-ui/index.css")).andReturn();
+        int status = result.getResponse().getStatus();
+        String location = result.getResponse().getHeader("Location");
+        assertThat(status).as("webjars path must not require JWT").isNotEqualTo(401);
+        assertThat(status == 302 && location != null && location.contains("oauth2/authorization"))
+                .as("webjars path must not redirect to OAuth2 login")
+                .isFalse();
+    }
+
+    @Test
+    void ws_unauthenticated_isPermitAll() throws Exception {
+        // /ws/** is permitAll() in Chain 2 — WebSocket upgrades must not require a JWT
+        // so that the browser client can connect without a Bearer token.
+        int status = mockMvc.perform(get("/ws/websocket")).andReturn().getResponse().getStatus();
+        assertThat(status).as("WebSocket path must not require authentication").isNotIn(401, 302);
+    }
+}

--- a/src/test/java/ch/furchert/homelab/device/controller/DeviceControllerTest.java
+++ b/src/test/java/ch/furchert/homelab/device/controller/DeviceControllerTest.java
@@ -1,18 +1,26 @@
 package ch.furchert.homelab.device.controller;
 
+import ch.furchert.homelab.device.config.SecurityConfig;
 import ch.furchert.homelab.device.entity.Device;
 import ch.furchert.homelab.device.service.DeviceService;
 import ch.furchert.homelab.device.service.MqttClientService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -26,6 +34,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * requests carry a mock JWT via {@code SecurityMockMvcRequestPostProcessors.jwt()}.
  */
 @WebMvcTest(DeviceController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = "DEVICE_SERVICE_CLIENT_SECRET=test")
 class DeviceControllerTest {
 
     @Autowired
@@ -39,6 +49,9 @@ class DeviceControllerTest {
 
     @MockitoBean
     private MqttClientService mqttClientService;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
 
     // -------------------------------------------------------------------------
     // GET /devices
@@ -108,13 +121,7 @@ class DeviceControllerTest {
                         .content(body))
                 .andExpect(status().isOk());
 
-        // Verify MQTT publish was called with the correct topic
-        verify(mqttClientService).publish(
-                eq("terra1/light/man"),
-                eq("{\"LightState\":1}"),
-                eq(1),
-                eq(false)
-        );
+        verify(mqttClientService).publish("terra1/light/man", "{\"LightState\":1}", 1, false);
     }
 
     @Test
@@ -132,11 +139,13 @@ class DeviceControllerTest {
         verifyNoInteractions(mqttClientService);
     }
 
-    @Test
-    void controlDevice_missingField_returns400() throws Exception {
-        // "field" is @NotBlank — omitting it should trigger validation failure
-        String body = "{\"state\":1}";
+    // -------------------------------------------------------------------------
+    // POST /devices/{id}/control — validation (parameterised)
+    // -------------------------------------------------------------------------
 
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidControlBodies")
+    void controlDevice_invalidBody_returns400(String description, String body) throws Exception {
         mockMvc.perform(post("/devices/1/control")
                         .with(jwt())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -144,15 +153,13 @@ class DeviceControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
-    @Test
-    void controlDevice_missingState_returns400() throws Exception {
-        // "state" is @NotNull — omitting it should trigger validation failure
-        String body = "{\"field\":\"light\"}";
-
-        mockMvc.perform(post("/devices/1/control")
-                        .with(jwt())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andExpect(status().isBadRequest());
+    static Stream<Arguments> invalidControlBodies() {
+        return Stream.of(
+                Arguments.of("field missing (@NotBlank)",          "{\"state\":1}"),
+                Arguments.of("state missing (@NotNull)",           "{\"field\":\"light\"}"),
+                Arguments.of("field not matching pattern",         "{\"field\":\"temperature\",\"state\":1}"),
+                Arguments.of("state below @Min(0)",                "{\"field\":\"light\",\"state\":-1}"),
+                Arguments.of("state above @Max(1)",                "{\"field\":\"light\",\"state\":2}")
+        );
     }
 }

--- a/src/test/java/ch/furchert/homelab/device/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/ch/furchert/homelab/device/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,122 @@
+package ch.furchert.homelab.device.exception;
+
+import ch.furchert.homelab.device.config.SecurityConfig;
+import ch.furchert.homelab.device.controller.DeviceController;
+import ch.furchert.homelab.device.service.DeviceService;
+import ch.furchert.homelab.device.service.MqttClientService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests the {@link GlobalExceptionHandler} response payload contract.
+ *
+ * <p>Uses a real MVC stack ({@link WebMvcTest}) to verify that:
+ * <ul>
+ *   <li>Validation failures produce a 400 with {@code error} + {@code details} keys.</li>
+ *   <li>Unhandled exceptions produce a 500 with only a {@code error} key and no
+ *       internal message is leaked to the caller.</li>
+ * </ul>
+ */
+@WebMvcTest(DeviceController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = "DEVICE_SERVICE_CLIENT_SECRET=test")
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DeviceService deviceService;
+
+    @MockitoBean
+    private MqttClientService mqttClientService;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    // -------------------------------------------------------------------------
+    // 400 — validation failure (MethodArgumentNotValidException)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void validationFailure_returns400WithErrorKey() throws Exception {
+        // "field" value violates @Pattern — triggers MethodArgumentNotValidException
+        String body = "{\"field\":\"invalid-field\",\"state\":1}";
+
+        mockMvc.perform(post("/devices/1/control")
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Validation failed"));
+    }
+
+    @Test
+    void validationFailure_returns400WithDetailsArray() throws Exception {
+        String body = "{\"field\":\"invalid-field\",\"state\":1}";
+
+        mockMvc.perform(post("/devices/1/control")
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.details").isArray())
+                .andExpect(jsonPath("$.details.length()").value(greaterThan(0)));
+    }
+
+    @Test
+    void validationFailure_detailsDescribeViolatedField() throws Exception {
+        // Both field and state violate constraints simultaneously
+        String body = "{\"field\":\"bad\",\"state\":99}";
+
+        mockMvc.perform(post("/devices/1/control")
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.details").isArray())
+                // Each detail string starts with the field name
+                .andExpect(jsonPath("$.details", hasItem(org.hamcrest.Matchers.startsWith("field:"))));
+    }
+
+    // -------------------------------------------------------------------------
+    // 500 — unhandled exception
+    // -------------------------------------------------------------------------
+
+    @Test
+    void unhandledException_returns500WithGenericErrorKey() throws Exception {
+        when(deviceService.getAllDevices()).thenThrow(new RuntimeException("DB down"));
+
+        mockMvc.perform(get("/devices").with(jwt()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.error").value("Internal server error"));
+    }
+
+    @Test
+    void unhandledException_doesNotLeakInternalExceptionMessage() throws Exception {
+        when(deviceService.getAllDevices()).thenThrow(new RuntimeException("secret-internal-message"));
+
+        mockMvc.perform(get("/devices").with(jwt()))
+                .andExpect(status().isInternalServerError())
+                // The raw exception message must never reach the response body
+                .andExpect(jsonPath("$.error").value(not("secret-internal-message")))
+                .andExpect(jsonPath("$").value(not(org.hamcrest.Matchers.hasKey("details"))));
+    }
+}

--- a/src/test/java/ch/furchert/homelab/device/service/MqttClientServiceTest.java
+++ b/src/test/java/ch/furchert/homelab/device/service/MqttClientServiceTest.java
@@ -99,10 +99,11 @@ class MqttClientServiceTest {
 
     @Test
     void connect_brokerConnectException_doesNotPropagate() {
-        try (var _ = Mockito.mockConstruction(MqttClient.class,
+        try (MockedConstruction<MqttClient> mocked = Mockito.mockConstruction(MqttClient.class,
                 (mock, ctx) -> doThrow(new MqttException(MqttException.REASON_CODE_CONNECTION_LOST))
                         .when(mock).connect(any()))) {
             assertThatCode(service::connect).doesNotThrowAnyException();
+            assertThat(mocked.constructed()).hasSize(1);
         }
     }
 

--- a/src/test/java/ch/furchert/homelab/device/service/MqttClientServiceTest.java
+++ b/src/test/java/ch/furchert/homelab/device/service/MqttClientServiceTest.java
@@ -1,0 +1,249 @@
+package ch.furchert.homelab.device.service;
+
+import ch.furchert.homelab.device.config.MqttProperties;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link MqttClientService}.
+ *
+ * <p>Uses {@link MockedConstruction} to intercept {@code new MqttClient(...)} and avoid
+ * any real broker connection while still verifying the full service logic.
+ */
+@ExtendWith(MockitoExtension.class)
+class MqttClientServiceTest {
+
+    @Mock
+    private MqttProperties props;
+
+    @Mock
+    private MqttMessageHandler messageHandler;
+
+    private MqttClientService service;
+
+    @BeforeEach
+    void setUp() {
+        // Lenient: only tests that call connect() consume these stubs.
+        lenient().when(props.getBrokerUrl()).thenReturn("tcp://localhost:1883");
+        lenient().when(props.getClientId()).thenReturn("test-client");
+        lenient().when(props.getTopics()).thenReturn(List.of("terra1/#", "terra2/#"));
+        lenient().when(props.getQos()).thenReturn(1);
+        lenient().when(props.getWillTopic()).thenReturn("javaBackend/mqtt/status");
+        lenient().when(props.getWillPayload()).thenReturn("{\"MqttState\": 0}");
+
+        service = new MqttClientService(props, messageHandler);
+    }
+
+    // -------------------------------------------------------------------------
+    // connect()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void connect_createsClientAndConnectsWithAutoReconnectAndLwt() throws Exception {
+        try (MockedConstruction<MqttClient> mocked = Mockito.mockConstruction(MqttClient.class)) {
+            service.connect();
+
+            assertThat(mocked.constructed()).hasSize(1);
+            MqttClient client = mocked.constructed().get(0);
+
+            verify(client).setCallback(service);
+
+            ArgumentCaptor<MqttConnectOptions> optsCaptor =
+                    ArgumentCaptor.forClass(MqttConnectOptions.class);
+            verify(client).connect(optsCaptor.capture());
+
+            MqttConnectOptions opts = optsCaptor.getValue();
+            assertThat(opts.isAutomaticReconnect()).isTrue();
+            assertThat(opts.isCleanSession()).isTrue();
+            assertThat(opts.getWillDestination()).isEqualTo("javaBackend/mqtt/status");
+        }
+    }
+
+    @Test
+    void connect_withCredentials_setsUsernameAndPasswordOnOptions() throws Exception {
+        when(props.getUsername()).thenReturn("mqttuser");
+        when(props.getPassword()).thenReturn("secret");
+
+        try (MockedConstruction<MqttClient> mocked = Mockito.mockConstruction(MqttClient.class)) {
+            service.connect();
+
+            MqttClient client = mocked.constructed().get(0);
+            ArgumentCaptor<MqttConnectOptions> optsCaptor =
+                    ArgumentCaptor.forClass(MqttConnectOptions.class);
+            verify(client).connect(optsCaptor.capture());
+
+            MqttConnectOptions opts = optsCaptor.getValue();
+            assertThat(opts.getUserName()).isEqualTo("mqttuser");
+            assertThat(new String(opts.getPassword())).isEqualTo("secret");
+        }
+    }
+
+    @Test
+    void connect_brokerConnectException_doesNotPropagate() {
+        try (var _ = Mockito.mockConstruction(MqttClient.class,
+                (mock, ctx) -> doThrow(new MqttException(MqttException.REASON_CODE_CONNECTION_LOST))
+                        .when(mock).connect(any()))) {
+            assertThatCode(service::connect).doesNotThrowAnyException();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // connectComplete() — called by broker after (re-)connect
+    // -------------------------------------------------------------------------
+
+    @Test
+    void connectComplete_subscribesToAllConfiguredTopics() throws Exception {
+        try (MockedConstruction<MqttClient> mocked = Mockito.mockConstruction(MqttClient.class,
+                (mock, ctx) -> when(mock.isConnected()).thenReturn(true))) {
+            service.connect();
+            service.connectComplete(false, "tcp://localhost:1883");
+
+            MqttClient client = mocked.constructed().get(0);
+            verify(client).subscribe("terra1/#", 1);
+            verify(client).subscribe("terra2/#", 1);
+        }
+    }
+
+    @Test
+    void connectComplete_publishesOnlineStatusRetained() throws Exception {
+        try (MockedConstruction<MqttClient> mocked = Mockito.mockConstruction(MqttClient.class,
+                (mock, ctx) -> when(mock.isConnected()).thenReturn(true))) {
+            service.connect();
+            service.connectComplete(false, "tcp://localhost:1883");
+
+            MqttClient client = mocked.constructed().get(0);
+            ArgumentCaptor<MqttMessage> msgCaptor = ArgumentCaptor.forClass(MqttMessage.class);
+            verify(client, atLeastOnce()).publish(eq("javaBackend/mqtt/status"), msgCaptor.capture());
+
+            boolean hasOnlinePayload = msgCaptor.getAllValues().stream()
+                    .anyMatch(m -> "{\"MqttState\": 1}".equals(
+                            new String(m.getPayload(), StandardCharsets.UTF_8)));
+            assertThat(hasOnlinePayload).isTrue();
+        }
+    }
+
+    @Test
+    void connectComplete_onReconnect_alsoSubscribesAndPublishes() throws Exception {
+        try (MockedConstruction<MqttClient> mocked = Mockito.mockConstruction(MqttClient.class,
+                (mock, ctx) -> when(mock.isConnected()).thenReturn(true))) {
+            service.connect();
+            service.connectComplete(true, "tcp://localhost:1883"); // reconnect = true
+
+            MqttClient client = mocked.constructed().get(0);
+            verify(client).subscribe("terra1/#", 1);
+            verify(client).subscribe("terra2/#", 1);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // messageArrived()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void messageArrived_delegatesToMessageHandler() {
+        MqttMessage mqttMsg = new MqttMessage("payload".getBytes(StandardCharsets.UTF_8));
+        service.messageArrived("terra1/SHT35/data", mqttMsg);
+        verify(messageHandler).handle("terra1/SHT35/data", "payload");
+    }
+
+    @Test
+    void messageArrived_handlerThrowsRuntimeException_doesNotPropagate() {
+        doThrow(new RuntimeException("boom")).when(messageHandler).handle(any(), any());
+        MqttMessage mqttMsg = new MqttMessage("{}".getBytes(StandardCharsets.UTF_8));
+        assertThatCode(() -> service.messageArrived("terra1/SHT35/data", mqttMsg))
+                .doesNotThrowAnyException();
+    }
+
+    // -------------------------------------------------------------------------
+    // disconnect()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void disconnect_publishesOfflineStatusAndClosesConnection() throws Exception {
+        try (MockedConstruction<MqttClient> mocked = Mockito.mockConstruction(MqttClient.class,
+                (mock, ctx) -> when(mock.isConnected()).thenReturn(true))) {
+            service.connect();
+            service.disconnect();
+
+            MqttClient client = mocked.constructed().get(0);
+            ArgumentCaptor<MqttMessage> msgCaptor = ArgumentCaptor.forClass(MqttMessage.class);
+            verify(client, atLeastOnce()).publish(eq("javaBackend/mqtt/status"), msgCaptor.capture());
+
+            boolean hasOfflinePayload = msgCaptor.getAllValues().stream()
+                    .anyMatch(m -> "{\"MqttState\": 0}".equals(
+                            new String(m.getPayload(), StandardCharsets.UTF_8)));
+            assertThat(hasOfflinePayload).isTrue();
+
+            verify(client).disconnect();
+            verify(client).close();
+        }
+    }
+
+    @Test
+    void disconnect_whenClientNeverInitialized_doesNotThrow() {
+        // connect() never called — client field is null
+        assertThatCode(service::disconnect).doesNotThrowAnyException();
+    }
+
+    // -------------------------------------------------------------------------
+    // publish()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void publish_whenConnected_sendsMessageWithCorrectQosAndRetained() throws Exception {
+        try (MockedConstruction<MqttClient> mocked = Mockito.mockConstruction(MqttClient.class,
+                (mock, ctx) -> when(mock.isConnected()).thenReturn(true))) {
+            service.connect();
+            service.publish("test/topic", "hello", 1, false);
+
+            MqttClient client = mocked.constructed().get(0);
+            ArgumentCaptor<MqttMessage> msgCaptor = ArgumentCaptor.forClass(MqttMessage.class);
+            verify(client, atLeastOnce()).publish(eq("test/topic"), msgCaptor.capture());
+
+            MqttMessage sent = msgCaptor.getAllValues().stream()
+                    .filter(m -> "hello".equals(new String(m.getPayload(), StandardCharsets.UTF_8)))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(sent.getQos()).isEqualTo(1);
+            assertThat(sent.isRetained()).isFalse();
+        }
+    }
+
+    @Test
+    void publish_whenClientDisconnected_doesNotCallClientPublish() throws Exception {
+        try (MockedConstruction<MqttClient> mocked = Mockito.mockConstruction(MqttClient.class,
+                (mock, ctx) -> when(mock.isConnected()).thenReturn(false))) {
+            service.connect();
+            service.publish("test/topic", "hello", 1, false);
+
+            MqttClient client = mocked.constructed().get(0);
+            verify(client, never()).publish(any(String.class), any(MqttMessage.class));
+        }
+    }
+
+    @Test
+    void publish_whenClientNull_doesNotThrow() {
+        // connect() never called — client is null
+        assertThatCode(() -> service.publish("test/topic", "hello", 1, false))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/ch/furchert/homelab/device/service/MqttMessageHandlerTest.java
+++ b/src/test/java/ch/furchert/homelab/device/service/MqttMessageHandlerTest.java
@@ -1,0 +1,145 @@
+package ch.furchert.homelab.device.service;
+
+import ch.furchert.homelab.device.service.ParsedMqttMessage.MessageType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link MqttMessageHandler}.
+ *
+ * <p>Verifies the parse → dispatch routing:
+ * <ul>
+ *   <li>SENSOR_DATA → {@link DeviceService#updateDeviceState} + {@link InfluxWriterService#write}</li>
+ *   <li>All other recognised types → {@link DeviceService#updateDeviceState} only</li>
+ *   <li>UNKNOWN → neither service called</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+class MqttMessageHandlerTest {
+
+    @Mock
+    private MqttMessageParser parser;
+
+    @Mock
+    private DeviceService deviceService;
+
+    @Mock
+    private InfluxWriterService influxWriterService;
+
+    private MqttMessageHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new MqttMessageHandler(parser, deviceService, influxWriterService);
+    }
+
+    // -------------------------------------------------------------------------
+    // SENSOR_DATA — both DeviceService and InfluxWriterService called
+    // -------------------------------------------------------------------------
+
+    @Test
+    void handle_sensorData_updatesDeviceAndWritesToInflux() {
+        ParsedMqttMessage msg = sensorDataMsg("terra1", 22.5, 65.0);
+        when(parser.parse("terra1/SHT35/data", "{}")).thenReturn(msg);
+
+        handler.handle("terra1/SHT35/data", "{}");
+
+        verify(deviceService).updateDeviceState(msg);
+        verify(influxWriterService).write(msg);
+    }
+
+    // -------------------------------------------------------------------------
+    // MQTT_STATUS — DeviceService only, Influx NOT called
+    // -------------------------------------------------------------------------
+
+    @Test
+    void handle_mqttStatus_updatesDeviceButDoesNotWriteToInflux() {
+        ParsedMqttMessage msg = new ParsedMqttMessage(
+                "terra1", MessageType.MQTT_STATUS, null, null, true, null, null, null);
+        when(parser.parse("terra1/mqtt/status", "{}")).thenReturn(msg);
+
+        handler.handle("terra1/mqtt/status", "{}");
+
+        verify(deviceService).updateDeviceState(msg);
+        verifyNoInteractions(influxWriterService);
+    }
+
+    // -------------------------------------------------------------------------
+    // LIGHT_STATE — DeviceService only, Influx NOT called
+    // -------------------------------------------------------------------------
+
+    @Test
+    void handle_lightState_updatesDeviceButDoesNotWriteToInflux() {
+        ParsedMqttMessage msg = new ParsedMqttMessage(
+                "terra1", MessageType.LIGHT_STATE, null, null, null, "1", null, null);
+        when(parser.parse(any(), any())).thenReturn(msg);
+
+        handler.handle("terra1/light", "{\"LightState\":1}");
+
+        verify(deviceService).updateDeviceState(msg);
+        verifyNoInteractions(influxWriterService);
+    }
+
+    // -------------------------------------------------------------------------
+    // NIGHT_LIGHT_STATE — DeviceService only, Influx NOT called
+    // -------------------------------------------------------------------------
+
+    @Test
+    void handle_nightLightState_updatesDeviceButDoesNotWriteToInflux() {
+        ParsedMqttMessage msg = new ParsedMqttMessage(
+                "terra1", MessageType.NIGHT_LIGHT_STATE, null, null, null, null, "0", null);
+        when(parser.parse(any(), any())).thenReturn(msg);
+
+        handler.handle("terra1/nightLight", "{\"NightLightState\":0}");
+
+        verify(deviceService).updateDeviceState(msg);
+        verifyNoInteractions(influxWriterService);
+    }
+
+    // -------------------------------------------------------------------------
+    // RAIN_STATE — DeviceService only, Influx NOT called
+    // -------------------------------------------------------------------------
+
+    @Test
+    void handle_rainState_updatesDeviceButDoesNotWriteToInflux() {
+        ParsedMqttMessage msg = new ParsedMqttMessage(
+                "terra2", MessageType.RAIN_STATE, null, null, null, null, null, "1");
+        when(parser.parse(any(), any())).thenReturn(msg);
+
+        handler.handle("terra2/rain", "{\"RainState\":1}");
+
+        verify(deviceService).updateDeviceState(msg);
+        verifyNoInteractions(influxWriterService);
+    }
+
+    // -------------------------------------------------------------------------
+    // UNKNOWN — neither service called
+    // -------------------------------------------------------------------------
+
+    @Test
+    void handle_unknownMessage_neitherServiceIsCalled() {
+        ParsedMqttMessage msg = new ParsedMqttMessage(
+                null, MessageType.UNKNOWN, null, null, null, null, null, null);
+        when(parser.parse(any(), any())).thenReturn(msg);
+
+        handler.handle("unknown/topic", "{}");
+
+        verifyNoInteractions(deviceService);
+        verifyNoInteractions(influxWriterService);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private static ParsedMqttMessage sensorDataMsg(String device, double temp, double humidity) {
+        return new ParsedMqttMessage(
+                device, MessageType.SENSOR_DATA, temp, humidity, null, null, null, null);
+    }
+}

--- a/src/test/java/ch/furchert/homelab/device/service/MqttMessageParserTest.java
+++ b/src/test/java/ch/furchert/homelab/device/service/MqttMessageParserTest.java
@@ -245,8 +245,9 @@ class MqttMessageParserTest {
 
     // -------------------------------------------------------------------------
     // Wrong JSON type — key present but value is a string, not a number
-    // Jackson's asInt() on a non-numeric text node returns 0; message is still
-    // parsed (not rejected), so state is "0". This tests the current contract.
+    // Jackson 3 (tools.jackson): asInt() on a non-numeric TextNode throws rather
+    // than returning 0 as Jackson 2 did. The parser catches the exception and
+    // returns UNKNOWN.
     // -------------------------------------------------------------------------
 
     @Test

--- a/src/test/java/ch/furchert/homelab/device/service/MqttMessageParserTest.java
+++ b/src/test/java/ch/furchert/homelab/device/service/MqttMessageParserTest.java
@@ -214,4 +214,53 @@ class MqttMessageParserTest {
             assertThat(result.type()).isEqualTo(ParsedMqttMessage.MessageType.UNKNOWN);
         });
     }
+
+    // -------------------------------------------------------------------------
+    // Missing key — non-sensor message types
+    // -------------------------------------------------------------------------
+
+    @Test
+    void parse_mqttStatus_missingMqttStateKey_returnsUnknown() {
+        ParsedMqttMessage result = parser.parse("terra1/mqtt/status", "{}");
+        assertThat(result.type()).isEqualTo(ParsedMqttMessage.MessageType.UNKNOWN);
+    }
+
+    @Test
+    void parse_lightState_missingLightStateKey_returnsUnknown() {
+        ParsedMqttMessage result = parser.parse("terra1/light", "{}");
+        assertThat(result.type()).isEqualTo(ParsedMqttMessage.MessageType.UNKNOWN);
+    }
+
+    @Test
+    void parse_nightLightState_missingNightLightStateKey_returnsUnknown() {
+        ParsedMqttMessage result = parser.parse("terra1/nightLight", "{}");
+        assertThat(result.type()).isEqualTo(ParsedMqttMessage.MessageType.UNKNOWN);
+    }
+
+    @Test
+    void parse_rainState_missingRainStateKey_returnsUnknown() {
+        ParsedMqttMessage result = parser.parse("terra1/rain", "{}");
+        assertThat(result.type()).isEqualTo(ParsedMqttMessage.MessageType.UNKNOWN);
+    }
+
+    // -------------------------------------------------------------------------
+    // Wrong JSON type — key present but value is a string, not a number
+    // Jackson's asInt() on a non-numeric text node returns 0; message is still
+    // parsed (not rejected), so state is "0". This tests the current contract.
+    // -------------------------------------------------------------------------
+
+    @Test
+    void parse_lightState_stringValueForKey_returnsUnknown() {
+        // In Jackson 3 (tools.jackson), asInt() on a non-numeric TextNode throws rather than
+        // returning 0. The parser catches the exception and returns UNKNOWN.
+        ParsedMqttMessage result = parser.parse("terra1/light", "{\"LightState\":\"on\"}");
+        assertThat(result.type()).isEqualTo(ParsedMqttMessage.MessageType.UNKNOWN);
+    }
+
+    @Test
+    void parse_mqttStatus_stringValueForKey_returnsUnknown() {
+        // In Jackson 3 (tools.jackson), asInt() on a non-numeric TextNode throws.
+        ParsedMqttMessage result = parser.parse("terra1/mqtt/status", "{\"MqttState\":\"on\"}");
+        assertThat(result.type()).isEqualTo(ParsedMqttMessage.MessageType.UNKNOWN);
+    }
 }

--- a/src/test/java/ch/furchert/homelab/device/service/SchedulerServiceTest.java
+++ b/src/test/java/ch/furchert/homelab/device/service/SchedulerServiceTest.java
@@ -5,6 +5,7 @@ import ch.furchert.homelab.device.repository.ScheduleRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -12,7 +13,6 @@ import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 
@@ -190,5 +190,71 @@ class SchedulerServiceTest {
         verifyNoInteractions(taskScheduler);
         // The existing future must remain unchanged
         assertThat((Object) activeTasks().get(1L)).isSameAs(existingFuture);
+    }
+
+    // -------------------------------------------------------------------------
+    // Runnable execution — verify actual MQTT publish topic and payload
+    // -------------------------------------------------------------------------
+
+    @Test
+    void reloadSchedules_taskRunnable_publishesToCorrectTopicAndPayload() {
+        Schedule schedule = buildSchedule(1L, "light", "0 0 8 * * *");
+        when(scheduleRepository.findByActiveTrue()).thenReturn(List.of(schedule));
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        @SuppressWarnings("unchecked")
+        ScheduledFuture<Object> mockFuture = mock(ScheduledFuture.class);
+        doReturn(mockFuture)
+                .when(taskScheduler).schedule(runnableCaptor.capture(), any(CronTrigger.class));
+
+        schedulerService.reloadSchedules();
+
+        // Run the captured task as if the cron fired
+        runnableCaptor.getValue().run();
+
+        verify(mqttClientService).publish(
+                "terraGeneral/light/schedule",
+                "{\"LightState\": 1}",
+                1,
+                false
+        );
+    }
+
+    @Test
+    void reloadSchedules_taskRunnable_rainField_publishesToRainScheduleTopic() {
+        Schedule schedule = buildSchedule(2L, "rain", "0 0 20 * * *");
+        when(scheduleRepository.findByActiveTrue()).thenReturn(List.of(schedule));
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        @SuppressWarnings("unchecked")
+        ScheduledFuture<Object> mockFuture = mock(ScheduledFuture.class);
+        doReturn(mockFuture)
+                .when(taskScheduler).schedule(runnableCaptor.capture(), any(CronTrigger.class));
+
+        schedulerService.reloadSchedules();
+        runnableCaptor.getValue().run();
+
+        verify(mqttClientService).publish(
+                "terraGeneral/rain/schedule",
+                "{\"RainState\": 1}",
+                1,
+                false
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // schedule() returns null — task must not be registered
+    // -------------------------------------------------------------------------
+
+    @Test
+    void reloadSchedules_schedulerReturnsNull_taskNotAddedToActiveTasks() {
+        Schedule schedule = buildSchedule(1L, "light", "0 0 8 * * *");
+        when(scheduleRepository.findByActiveTrue()).thenReturn(List.of(schedule));
+        doReturn(null).when(taskScheduler).schedule(any(Runnable.class), any(CronTrigger.class));
+
+        schedulerService.reloadSchedules();
+
+        assertThat(activeTasks()).doesNotContainKey(1L);
+        assertThat(taskFingerprints()).doesNotContainKey(1L);
     }
 }

--- a/src/test/java/ch/furchert/homelab/device/service/WebSocketBroadcastServiceTest.java
+++ b/src/test/java/ch/furchert/homelab/device/service/WebSocketBroadcastServiceTest.java
@@ -1,0 +1,122 @@
+package ch.furchert.homelab.device.service;
+
+import ch.furchert.homelab.device.dto.DeviceStateDto;
+import ch.furchert.homelab.device.entity.Device;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link WebSocketBroadcastService}.
+ *
+ * <p>Verifies the STOMP destination pattern and the complete field-to-DTO mapping
+ * performed before sending to connected WebSocket clients.
+ */
+@ExtendWith(MockitoExtension.class)
+class WebSocketBroadcastServiceTest {
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    private WebSocketBroadcastService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WebSocketBroadcastService(messagingTemplate);
+    }
+
+    // -------------------------------------------------------------------------
+    // Destination topic
+    // -------------------------------------------------------------------------
+
+    @Test
+    void broadcastDeviceState_sendsToTopicTerrariumDeviceName() {
+        Device device = Device.builder().id(1L).name("terra1").build();
+
+        service.broadcastDeviceState(device);
+
+        verify(messagingTemplate).convertAndSend(
+                eq("/topic/terrarium/terra1"), any(DeviceStateDto.class));
+    }
+
+    @Test
+    void broadcastDeviceState_topicContainsDeviceName() {
+        Device device = Device.builder().id(2L).name("terra2").build();
+
+        service.broadcastDeviceState(device);
+
+        verify(messagingTemplate).convertAndSend(
+                argThat((String dest) -> dest.endsWith("/terra2")),
+                any(DeviceStateDto.class));
+    }
+
+    // -------------------------------------------------------------------------
+    // DTO field mapping
+    // -------------------------------------------------------------------------
+
+    @Test
+    void broadcastDeviceState_mapsAllFieldsToDto() {
+        LocalDateTime lastSeen = LocalDateTime.of(2026, 4, 14, 12, 0, 0);
+        Device device = Device.builder()
+                .id(1L)
+                .name("terra1")
+                .mqttOnline(true)
+                .temperature(22.5)
+                .humidity(65.0)
+                .light("1")
+                .nightLight("0")
+                .rain("1")
+                .lastSeen(lastSeen)
+                .build();
+
+        service.broadcastDeviceState(device);
+
+        ArgumentCaptor<DeviceStateDto> captor = ArgumentCaptor.forClass(DeviceStateDto.class);
+        verify(messagingTemplate).convertAndSend(any(String.class), captor.capture());
+
+        DeviceStateDto dto = captor.getValue();
+        assertThat(dto.id()).isEqualTo(1L);
+        assertThat(dto.name()).isEqualTo("terra1");
+        assertThat(dto.mqttOnline()).isTrue();
+        assertThat(dto.temperature()).isEqualTo(22.5);
+        assertThat(dto.humidity()).isEqualTo(65.0);
+        assertThat(dto.light()).isEqualTo("1");
+        assertThat(dto.nightLight()).isEqualTo("0");
+        assertThat(dto.rain()).isEqualTo("1");
+        assertThat(dto.lastSeen()).isEqualTo(lastSeen.toString());
+    }
+
+    @Test
+    void broadcastDeviceState_withNullLastSeen_dtoLastSeenIsNull() {
+        Device device = Device.builder().id(1L).name("terra1").mqttOnline(false).build();
+
+        service.broadcastDeviceState(device);
+
+        ArgumentCaptor<DeviceStateDto> captor = ArgumentCaptor.forClass(DeviceStateDto.class);
+        verify(messagingTemplate).convertAndSend(any(String.class), captor.capture());
+        assertThat(captor.getValue().lastSeen()).isNull();
+    }
+
+    @Test
+    void broadcastDeviceState_offlineDevice_dtoMqttOnlineFalse() {
+        Device device = Device.builder().id(1L).name("terra1").mqttOnline(false).build();
+
+        service.broadcastDeviceState(device);
+
+        ArgumentCaptor<DeviceStateDto> captor = ArgumentCaptor.forClass(DeviceStateDto.class);
+        verify(messagingTemplate).convertAndSend(any(String.class), captor.capture());
+        assertThat(captor.getValue().mqttOnline()).isFalse();
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -7,6 +7,26 @@ spring:
     enabled: true
     table: flyway_schema_history_device
 
+  # Override OAuth2 client provider to avoid OIDC discovery HTTP call at startup in tests
+  security:
+    oauth2:
+      client:
+        registration:
+          device-service:
+            provider: auth-service
+            client-id: device-service
+            client-secret: ${DEVICE_SERVICE_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/device-service"
+            scope: openid,profile,email
+        provider:
+          auth-service:
+            authorization-uri: http://localhost/oauth2/authorize
+            token-uri: http://localhost/oauth2/token
+            jwk-set-uri: http://localhost/oauth2/jwks
+            user-info-uri: http://localhost/userinfo
+            user-name-attribute: sub
+
 sentry:
   enabled: false
   dsn:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -15,7 +15,7 @@ spring:
           device-service:
             provider: auth-service
             client-id: device-service
-            client-secret: ${DEVICE_SERVICE_CLIENT_SECRET}
+            client-secret: ${DEVICE_SERVICE_CLIENT_SECRET:test}
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/device-service"
             scope: openid,profile,email


### PR DESCRIPTION
…lidation

## New test classes:
  - MqttClientServiceTest (13): connect options/credentials/exception, connectComplete subscribe+online publish, messageArrived delegation+swallowed exception, disconnect offline publish+close, publish connected/disconnected/null-client
  - MqttMessageHandlerTest (6): SENSOR_DATA→Influx written, MQTT_STATUS/LIGHT/NIGHT_LIGHT/RAIN→Influx not called, UNKNOWN→no service calls
  - WebSocketBroadcastServiceTest (5): destination topic pattern, full DTO mapping, null lastSeen, offline device, per-device-name topic
  - GlobalExceptionHandlerTest (5): 400 error+details keys, details array, field name in detail string, 500 generic error, exception message not leaked

## Extended existing tests:
  - DeviceControllerTest (+3): field regex violation, state below @Min, state above @Max
  - MqttMessageParserTest (+6): missing key for MQTT_STATUS/LIGHT/NIGHT_LIGHT/RAIN, string-value-for-numeric-key → UNKNOWN (Jackson 3 throws, not coerces)
  - SchedulerServiceTest (+3): runnable executes publish to correct topic/payload, rain field topic, scheduler returning null → task not registered

# Fix 1: @Import(SecurityConfig.class) in DeviceControllerTest
  @WebMvcTest does NOT auto-load @Configuration beans. Without the import, Spring Boot test auto-config enables global oauth2Login (oauth2-client is on classpath), turning 401 responses into 302 redirects.

# Fix 2: swaggerUi_authenticated_isNotRedirectedToLogin assertion
  Changed to check specifically for OAuth2-redirect (302 to oauth2/authorization) and 401 — actual security failures. All other codes (including 500 from Springdoc in the slice context) mean security passed.

# Missing tests added to SecurityConfigTest
   3 new tests: /actuator/info is public, /webjars/** is permitAll() (no redirect), /ws/** is permitAll() (no JWT required).

# fix: resolve SonarLint issues across test files and k8s manifest
  - MqttClientServiceTest: remove redundant lenient import (covered by wildcard), drop unnecessary throws Exception on messageArrived tests, replace ignored var_ with unnamed variable, add assertThatCode() assertions to 4 no-assertion "doesNotThrow" tests
  - SchedulerServiceTest: remove unused Map import and eq import, replace eq() wrappers with plain values in all publish verify calls
  - SecurityConfigTest: replace throw new AssertionError() lambda patterns with AssertJ assertThat + andReturn() for actuator, webjars, ws and swagger authenticated tests
  - DeviceControllerTest: collapse 5 duplicate validation @Test methods into one @ParameterizedTest + @MethodSource, drop eq() from publish verify call
  - k8s/deployment.yaml: add automountServiceAccountToken: false to pod spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Swagger and API documentation endpoints now require OIDC authentication; unauthenticated users are automatically redirected to login.

* **Documentation**
  * Updated deployment, operations, and development setup guides with new required environment variable and updated OAuth2/JWKS configuration endpoints.

* **Tests**
  * Added comprehensive test coverage for security, MQTT messaging, exception handling, and WebSocket services.

* **Chores**
  * Updated GitHub Actions workflows with concurrency controls; updated Kubernetes deployment configuration; added OAuth2 client dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->